### PR TITLE
Update FlyhackControl to modify velocity directly

### DIFF
--- a/UE_UniversalCheat/Helper/Cheese.cpp
+++ b/UE_UniversalCheat/Helper/Cheese.cpp
@@ -259,7 +259,7 @@ void Cheese::FlyhackControl(SDK::APlayerController* Controller) {
     if (!PointerChecks::IsValidPtr(Controller->Character, "Controller->Character")) return;
 
     SDK::UWorld* World = SDK::UWorld::GetWorld();
-    float Delta = 0.16f;
+    float Delta = 0.016f;
     if (PointerChecks::IsValidPtr(World, "World"))
         Delta = static_cast<float>(SDK::UGameplayStatics::GetWorldDeltaSeconds(World));
 

--- a/UE_UniversalCheat/Helper/Cheese.cpp
+++ b/UE_UniversalCheat/Helper/Cheese.cpp
@@ -295,5 +295,5 @@ void Cheese::FlyhackControl(SDK::APlayerController* Controller) {
     }
 
     if (!Launch.IsZero())
-        Movement->Velocity = Launch;
+        Movement->Velocity += Launch;
 }

--- a/UE_UniversalCheat/Hooks/menu/menu.cpp
+++ b/UE_UniversalCheat/Hooks/menu/menu.cpp
@@ -163,13 +163,18 @@ namespace Menu {
 
             bool actorArrayValid = PointerChecks::IsValidPtr(ActorArray, "ActorArray") &&
                 ActorArray->IsValid();
-            AllEntsLevel = actorArrayValid ? ActorArray->Num() : 0;
 
             // 1)  neue / bisher unbekannte Actor in den Cache aufnehmen
-            for (int i = 0; actorArrayValid && i < AllEntsLevel; ++i)
+            AllEntsLevel = 0;
+            for (int i = 0; actorArrayValid && i < ActorArray->Num(); ++i)
             {
                 if (SDK::AActor* a = (*ActorArray)[i])
+                {
+                    if (PawnFilterEnabled && !a->IsA(SDK::APawn::StaticClass()))
+                        continue;
                     g_EntityCache.Add(a);              // (emplace ignoriert Duplikate)
+                    ++AllEntsLevel;
+                }
             }
 
             // 2)  Kamera updaten und Cache-Refresh (nur dynamische Daten)


### PR DESCRIPTION
## Summary
- adjust flyhack to add velocity rather than overwriting it
- guard actor array access with validity checks in the menu
- apply PawnFilterEnabled to actor cache to skip non-pawns

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688cca116c08832ebe90e00c8b73c4e1