### PR TITLE
Update FlyhackControl and overlay console handling

### DIFF
--- a/UE_UniversalCheat/Helper/Cheese.cpp
+++ b/UE_UniversalCheat/Helper/Cheese.cpp
@@ -298,5 +298,5 @@ void Cheese::FlyhackControl(SDK::APlayerController* Controller) {
     }
 
     if (!Launch.IsZero())
-        Controller->Character->LaunchCharacter(Launch, true, true);
+        Movement->Velocity += Launch;
 }

--- a/UE_UniversalCheat/Hooks/menu/menu.cpp
+++ b/UE_UniversalCheat/Hooks/menu/menu.cpp
@@ -161,13 +161,20 @@ namespace Menu {
                 reinterpret_cast<std::uintptr_t>(CurrentLevel) +
                 static_cast<std::uintptr_t>(selectedArrayOffset));
 
-            AllEntsLevel = ActorArray ? ActorArray->Num() : 0;
+            bool actorArrayValid = PointerChecks::IsValidPtr(ActorArray, "ActorArray") &&
+                ActorArray->IsValid();
 
             // 1)  neue / bisher unbekannte Actor in den Cache aufnehmen
-            for (int i = 0; i < AllEntsLevel; ++i)
+            AllEntsLevel = 0;
+            for (int i = 0; actorArrayValid && i < ActorArray->Num(); ++i)
             {
                 if (SDK::AActor* a = (*ActorArray)[i])
+                {
+                    if (PawnFilterEnabled && !a->IsA(SDK::APawn::StaticClass()))
+                        continue;
                     g_EntityCache.Add(a);              // (emplace ignoriert Duplikate)
+                    ++AllEntsLevel;
+                }
             }
 
             // 2)  Kamera updaten und Cache-Refresh (nur dynamische Daten)

--- a/UE_UniversalCheat/Overlay/Overlay.cpp
+++ b/UE_UniversalCheat/Overlay/Overlay.cpp
@@ -166,12 +166,23 @@ void RenderOverlay()
     ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
     bool show_another_window = false;
     ImVec4 clear_color = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
-
+    HWND consoleWindow = GetConsoleWindow();
     MSG msg;
     while (running)
     {
-        if (targetWindow)
-            SetOverlayToTarget(targetWindow, hWndOverlay);
+        bool consoleActive = GetForegroundWindow() == consoleWindow;
+        if (consoleActive)
+        {
+            ShowWindow(hWndOverlay, SW_HIDE);
+        }
+        else
+        {
+            ShowWindow(hWndOverlay, SW_SHOW);
+            if (targetWindow)
+                SetOverlayToTarget(targetWindow, hWndOverlay);
+            SetWindowPos(hWndOverlay, HWND_TOPMOST, 0, 0, 0, 0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        }
         // ✅ Windows-Nachrichten verarbeiten
         while (PeekMessage(&msg, NULL, 0U, 0U, PM_REMOVE)) {
             TranslateMessage(&msg);


### PR DESCRIPTION
## Summary
- adjust flyhack to add velocity rather than overwriting it
- guard actor array access with validity checks in the menu
- apply PawnFilterEnabled to actor cache to skip non-pawns
- hide overlay when debug console is active to avoid covering it

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c UE_UniversalCheat/Overlay/Overlay.cpp -IUE_UniversalCheat -o /tmp/overlay.o` *(fails: fatal error: Windows.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688cca116c08832ebe90e00c8b73c4e1